### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+script:
+- ./gradlew --scan build
 jdk:
   - oraclejdk8
   - oraclejdk9

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,13 @@ buildscript {
 }
 
 plugins {
+  id "com.gradle.build-scan" version "1.16"
   id "com.gradle.plugin-publish" version "0.9.9" apply false
+}
+
+buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
 }
 
 group 'org.jonnyzzz'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.